### PR TITLE
Reorganize Configuration Processing

### DIFF
--- a/0.preprocess-sites/0.prefilter-features.py
+++ b/0.preprocess-sites/0.prefilter-features.py
@@ -16,7 +16,7 @@ import pandas as pd
 from scripts.site_processing_utils import prefilter_features
 
 sys.path.append(os.path.join("..", "scripts"))
-from config_utils import get_config
+from config_utils import process_config_file
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -31,7 +31,7 @@ args = parser.parse_args()
 config_file = args.config_file
 force = args.force
 
-config = get_config(config_file)
+config = process_config_file(config_file)
 
 # Set constants
 core_args = config["core"]
@@ -42,16 +42,16 @@ batch = core_args["batch"]
 compartments = core_args["compartments"]
 
 perform = prefilter_args["perform"]
-example_site = prefilter_args["example_site"]
-example_dir = pathlib.PurePath(f'{core_args["batch_dir"]}/{example_site}')
+example_site_dir = prefilter_args["example_site_dir"]
 flag_cols = prefilter_args["flag_cols"]
-output_dir = prefilter_args["output_dir"]
-output_file = pathlib.PurePath(f"{output_dir}/feature_prefilter.tsv")
+output_file = prefilter_args["prefilter_file"]
 
-os.makedirs(output_dir, exist_ok=True)
+# Create the directory
+output_file.parent.mkdir(exist_ok=True)
 
+# Perform prefiltering and output file
 if perform:
-    features_df = prefilter_features(core_args, example_dir, flag_cols)
+    features_df = prefilter_features(core_args, example_site_dir, flag_cols)
 else:
     features_df = load_features(core_args, example_dir)
     features_df = features_df.assign(prefilter_column=False)
@@ -62,7 +62,7 @@ Use --force to overwrite.
 First, check 'perform' in the config.
 Note that 'perform: false' will still output a file lacking prefiltered features.
 """
-if pathlib.Path(output_file).exists():
+if output_file.exists():
     assert force, force_assert
 
 features_df.to_csv(output_file, sep="\t", index=False)

--- a/0.preprocess-sites/site_processing_config.yaml
+++ b/0.preprocess-sites/site_processing_config.yaml
@@ -4,8 +4,7 @@ core:
   pipeline: Pooled Cell Painting
   project: 2018_11_20_Periscope_Calico
   batch: 20190919_6W_CP074A
-  project_dir: /Users/gway/work/projects/2018_11_20_Periscope_Calico
-  data_dir: /workspace/analysis/20190919_6W_CP074A
+  project_dir: /Users/gway/work/projects/
   output_dir: data
   categorize_cell_quality: simple
   compartments:
@@ -31,7 +30,7 @@ core:
 prefilter:
   perform: true
   example_site: CP074A_A1-Site_1
-  output_dir: data
+  output_basedir: data
   flag_cols:
     - Barcode
     - Location

--- a/scripts/config_utils.py
+++ b/scripts/config_utils.py
@@ -18,29 +18,45 @@ def get_step(config):
 
 def make_batch_path(config, load_data=True):
     if load_data:
-        data = load_config(config)
-    else:
-        data = config
-    core = data["core"]
-    batch_dir = pathlib.PurePath(f'{core["project_dir"]}/{core["data_dir"]}')
+        config = load_config(config)
+    core = config["core"]
+    batch_dir = pathlib.Path(
+        core["project_dir"], core["project"], "workspace", "analysis", core["batch"],
+    )
     return batch_dir
 
 
 def preprocess_sites_config(config):
-    data = load_config(config)
-    batch_dir = make_batch_path(data, load_data=False)
-    data["core"]["batch_dir"] = batch_dir
-    return data
+    config = load_config(config)
+    batch_dir = make_batch_path(config, load_data=False)
+    config["core"]["batch_dir"] = batch_dir
+
+    # Build paths in the prefilter yaml document
+    config["prefilter"]["prefilter_file"] = pathlib.Path(
+        config["prefilter"]["output_basedir"],
+        config["core"]["batch"],
+        "feature_prefilter.tsv",
+    )
+    config["prefilter"]["example_site_dir"] = pathlib.Path(
+        batch_dir, config["prefilter"]["example_site"]
+    )
+
+    # Build paths in the process-spots yaml document
+    config["process-spots"]["output_spotdir"] = pathlib.Path(
+        config["process-spots"]["output_basedir"], config["core"]["batch"], "spots"
+    )
+
+    return config
 
 
 def generate_profiles_config(config):
-    data = load_config(config)
-    batch_dir = make_batch_path(data, load_data=False)
-    data["core"]["batch_dir"] = batch_dir
-    return data
+    config = load_config(config)
+    batch_dir = make_batch_path(config, load_data=False)
+    config["core"]["batch_dir"] = batch_dir
+    return config
 
 
-def get_config(config):
+def process_config_file(config):
     step = get_step(config)
     # Processes specified configuration file
     if step == "preprocess-sites":


### PR DESCRIPTION
As I was progressing the recipe to the `aggregate` profiling step, I recognized that it is very difficult to follow all the directories and locations of necessary files.

We need to strike a balance between modularity and overburdening our users. Since we are working towards a unified file structure in regular Cell Painting experiments (see cytomining/profiling-handbook/issues/54#issue-610880499) it makes sense to expect certain files and directory structure to never change. This removes unnecessary options from our users.

If in the rare event that CellProfiler output files change save locations after a Pooled Cell Painting image analysis pipeline, then we will have to revisit this structure and decision. For now, it makes development easier.