### PR TITLE
Adding Cell Painting Utility Methods

### DIFF
--- a/scripts/paint_utils.py
+++ b/scripts/paint_utils.py
@@ -1,0 +1,76 @@
+import pathlib
+import pandas as pd
+
+
+def load_single_cell_compartment_csv(compartment_dir, compartment, metadata_cols):
+    """
+    Load and process columns for CellProfiler output data
+
+    Arguments:
+    compartment_dir - path location of where the compartment csv files are stored
+    compartment - string representing the compartment to load (e.g. cytoplasm)
+    metadata_cols - a list of columns to add `Metadata_` prefix.
+        Note the entries should not already be prefixed by compartment
+        (e.g. AreaShape and not Cells_AreaShape)
+
+    Output:
+    A compartment dataframe with compartment prefixed column names
+    """
+    # Setup compartment file
+    compartment = compartment.capitalize()
+    compartment_file = pathlib.Path(compartment_dir, f"{compartment}.csv")
+
+    # Load compartment data
+    compartment_df = pd.read_csv(compartment_file)
+    compartment_df.columns = [f"{compartment}_{x}" for x in compartment_df.columns]
+
+    # Identify and rename metadata_cols
+    metadata_rename = {}
+    for col in metadata_cols:
+        metadata_col = f"Metadata_{compartment}_{col}"
+        metadata_rename[f"{compartment}_{col}"] = metadata_col
+
+    compartment_df = compartment_df.rename(metadata_rename, axis="columns")
+
+    return compartment_df
+
+
+def merge_single_cell_compartments(compartment_df_dict, merge_info_dict, id_cols):
+    """
+    Merge single cell compartment csvs using specified merge columns
+
+    Arguments:
+    compartment_df_dict - dictionary of pandas dataframes keyed by compartment name
+    merge_info_dict - stores merge information and is loaded directly from config file
+    id_cols - list of columns to identify single cell compartments, loaded from config
+
+    Output:
+    A single merged dataframe of all single cell measurements across compartments
+    """
+    # Extract expected merge information
+    link_compartment = merge_info_dict["linking_compartment"].capitalize()
+    linking_columns = merge_info_dict["linking_columns"]
+    image_col = merge_info_dict["image_column"]
+    link_compartment_col = f"Metadata_{link_compartment}_{image_col}"
+    linker_df = compartment_df_dict[link_compartment]
+
+    # Perform the merge given the linking compartment columns
+    for compartment, compartment_link in linking_columns.items():
+        # Pull compartment dataframe to link from the given dictionary
+        to_link_df = compartment_df_dict[compartment.capitalize()]
+
+        # Setup the columns to match between dataframes
+        link_merge_cols = (link_compartment_col, compartment_link)
+        to_link_compartment_cols = [
+            f"Metadata_{compartment.capitalize()}_{x}" for x in id_cols
+        ]
+
+        # Merge compartment dataframes
+        linker_df = linker_df.merge(
+            to_link_df,
+            left_on=link_merge_cols,
+            right_on=to_link_compartment_cols,
+            how="inner",
+        )
+
+    return linker_df


### PR DESCRIPTION
Here I add two methods which enable two functions:

1. Loading CellProfiler output `.csv` files for any specified compartment and adding column name prefixes
2. Merging compartment `.csv` files into a single dataframe given merge column information

## Example Usage

### Example Entry in Config YAML

```yaml
---
core:
  compartments:
    - Cells
    - Nuclei
    - Cytoplasm
parent_cols:
    cells:
      - Parent_Nuclei
    cytoplasm:
      - Parent_Nuclei
      - Parent_Cells
    spots:
      - Parent_Cells
  id_cols:
    - ImageNumber
    - ObjectNumber
---
aggregate:
  merge_cols:
    image_column: ImageNumber
    linking_compartment: Cytoplasm
    linking_columns:
      cells: Metadata_Cytoplasm_Parent_Cells
      nuclei: Metadata_Cytoplasm_Parent_Nuclei
```

### Example Usage in Processing

```python
from config_utils import process_config_file
from paint_utils import (
    load_single_cell_compartment_csv,
    merge_single_cell_compartments
)

config_file = <EXAMPLE YAML ABOVE>
config = process_config_file(config_file)

core_args = config["core"]
aggregate_args = config["aggregate"]

id_cols = core_args["id_cols"]
compartments = core_args["compartments"]
merge_info = aggregate_args["merge_cols"]

compartment_csvs = {}
for compartment in compartments:
    try:
        metadata_cols = parent_col_info[compartment.lower()] + id_cols
    except KeyError:
        metadata_cols = id_cols
    compartment_csvs[compartment] = load_single_cell_compartment_csv(
        site_compartment_dir, compartment, metadata_cols
    )

sc_merged_df = merge_single_cell_compartments(compartment_csvs, merge_info, id_cols)